### PR TITLE
Allow more container types to some functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 
 # Now simply link against gtest or gtest_main as needed. Eg
 add_executable(${PROJECT_NAME} tests/strutil_tests.cpp tests/test_cases.cpp strutil.h)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 
 if (COVERAGE)
     target_compile_options(${PROJECT_NAME} PRIVATE --coverage)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## strutil
-Easy to use, header only C++ 17 std::string utility library. 
+Easy to use, header only C++ 20 std::string utility library. 
 
 Any constructive comments and improvements to this little library are very welcome.
 

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -38,7 +38,7 @@ PROJECT_NAME           = strutil
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.0.2
+PROJECT_NUMBER         = 2.0.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ subprocess.call('doxygen Doxyfile.in', shell=True)
 # -- Project information -----------------------------------------------------
 
 project = u'strutil'
-copyright = u'2022, Tomasz Gałaj'
+copyright = u'2024, Tomasz Gałaj'
 author = u'Tomasz Gałaj'
 
 # The short X.Y version

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 strutil
 =======
 
-Easy to use, header only C++ 17 std::string utility library.
+Easy to use, header only C++ 20 std::string utility library.
 
 Any constructive comments and improvements to this little library are more than welcome.
 

--- a/strutil.h
+++ b/strutil.h
@@ -458,15 +458,15 @@ namespace strutil
     }
 
     /**
-     * @brief Joins all elements of std::vector tokens of arbitrary datatypes
+     * @brief Joins all elements of a container of arbitrary datatypes
      *        into one std::string with delimiter delim.
-     * @tparam T - arbitrary datatype.
-     * @param tokens - vector of tokens.
+     * @tparam Container - container type.
+     * @param tokens - container of tokens.
      * @param delim - the delimiter.
-     * @return std::string with joined elements of vector tokens with delimiter delim.
+     * @return std::string with joined elements of container tokens with delimiter delim.
      */
-    template<typename T>
-    static inline std::string join(const std::vector<T> & tokens, const std::string & delim)
+    template<typename Container>
+    static inline std::string join(const Container & tokens, const std::string & delim)
     {
         std::ostringstream result;
         for(auto it = tokens.begin(); it != tokens.end(); ++it)
@@ -483,21 +483,25 @@ namespace strutil
     }
 
     /**
-     * @brief Inplace removal of all empty strings in a vector<string>
-     * @param tokens - vector of strings.
+     * @brief Inplace removal of all empty strings in a container of strings
+     * @tparam Container - container type.
+     * @param tokens - container of strings.
      */
-    static inline void drop_empty(std::vector<std::string> & tokens)
+    template<template<class> class Container>
+    static inline void drop_empty(Container<std::string> & tokens)
     {
         auto last = std::remove_if(tokens.begin(), tokens.end(), [](const std::string& s){ return s.empty(); });
         tokens.erase(last, tokens.end());
     }
 
     /**
-     * @brief Inplace removal of all empty strings in a vector<string>
-     * @param tokens - vector of strings.
-     * @return vector of non-empty tokens.
+     * @brief Inplace removal of all empty strings in a container of strings
+     * @tparam container - container type.
+     * @param tokens - container of strings.
+     * @return container of non-empty tokens.
      */
-    static inline std::vector<std::string> drop_empty_copy(std::vector<std::string> tokens)
+    template<template<class> class Container>
+    static inline Container<std::string> drop_empty_copy(Container<std::string> tokens)
     {
         drop_empty(tokens);
         return tokens;
@@ -506,10 +510,12 @@ namespace strutil
     /**
      * @brief Inplace removal of all duplicate strings in a vector<string> where order is not to be maintained
      *        Taken from: C++ Primer V5
+     * @tparam T - arbitrary datatype.
      * @param tokens - vector of strings.
      * @return vector of non-duplicate tokens.
      */
-    static inline void drop_duplicate(std::vector<std::string> &tokens)
+    template<typename T>
+    static inline void drop_duplicate(std::vector<T> &tokens)
     {
         std::sort(std::execution::par_unseq, tokens.begin(), tokens.end());
         auto end_unique = std::unique(tokens.begin(), tokens.end());
@@ -519,10 +525,12 @@ namespace strutil
     /**
      * @brief Removal of all duplicate strings in a vector<string> where order is not to be maintained
      *        Taken from: C++ Primer V5
+     * @tparam T - arbitrary datatype.
      * @param tokens - vector of strings.
      * @return vector of non-duplicate tokens.
      */
-    static inline std::vector<std::string> drop_duplicate_copy(std::vector<std::string> tokens)
+    template<typename T>
+    static inline std::vector<T> drop_duplicate_copy(std::vector<T> tokens)
     {
         std::sort(std::execution::par_unseq, tokens.begin(), tokens.end());
         auto end_unique = std::unique(tokens.begin(), tokens.end());
@@ -591,21 +599,21 @@ namespace strutil
     }
 
     /**
-     * @brief Reverse input std::vector<std::string> strs.
-     * @param strs - std::vector<std::string> to be checked.
+     * @brief Reverse input container strs.
+     * @param strs - container to be checked.
      */
-    template<typename T>
-    static inline void reverse_inplace(std::vector<T> &strs)
+    template<typename Container>
+    static inline void reverse_inplace(Container &strs)
     {
         std::reverse(strs.begin(), strs.end());
     }
 
     /**
-     * @brief Reverse input std::vector<std::string> strs.
-     * @param strs - std::vector<std::string> to be checked.
+     * @brief Reverse input container strs.
+     * @param strs - container to be checked.
      */
-    template<typename T>
-    static inline std::vector<T> reverse_copy(std::vector<T> strs)
+    template<typename Container>
+    static inline Container reverse_copy(Container strs)
     {
         std::reverse(strs.begin(), strs.end());
         return strs;

--- a/strutil.h
+++ b/strutil.h
@@ -488,8 +488,8 @@ namespace strutil
      * @tparam Container - container type.
      * @param tokens - container of strings.
      */
-    template<template<typename> typename Container>
-    static inline void drop_empty(Container<std::string> & tokens)
+    template<template<typename, typename...> typename Container, typename... Args>
+    static inline void drop_empty(Container<std::string, Args...> & tokens)
     {
         auto last = std::erase_if(tokens, [](auto& s){ return s.empty(); });
     }
@@ -500,10 +500,10 @@ namespace strutil
      * @param tokens - container of strings.
      * @return container of non-empty tokens.
      */
-    template<template<typename> typename Container>
-    static inline Container<std::string> drop_empty_copy(Container<std::string> tokens)
+    template<template<typename, typename...> typename Container, typename... Args>
+    static inline Container<std::string> drop_empty_copy(Container<std::string, Args...> tokens)
     {
-        drop_empty<Container>(tokens);
+        drop_empty(tokens);
         return tokens;
     }
 

--- a/strutil.h
+++ b/strutil.h
@@ -1,7 +1,7 @@
  /**
  ******************************************************************************
  *
- *  @mainpage strutil v1.0.2 - header-only string utility library documentation
+ *  @mainpage strutil v2.0.0 - header-only string utility library documentation
  *  @see https://github.com/Shot511/strutil
  *
  *  @copyright  Copyright (C) 2024 Tomasz Galaj
@@ -20,6 +20,7 @@
 #include <execution>
 #include <map>
 #include <regex>
+#include <set>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -487,11 +488,10 @@ namespace strutil
      * @tparam Container - container type.
      * @param tokens - container of strings.
      */
-    template<template<class> class Container>
+    template<template<typename> typename Container>
     static inline void drop_empty(Container<std::string> & tokens)
     {
-        auto last = std::remove_if(tokens.begin(), tokens.end(), [](const std::string& s){ return s.empty(); });
-        tokens.erase(last, tokens.end());
+        auto last = std::erase_if(tokens, [](auto& s){ return s.empty(); });
     }
 
     /**
@@ -500,10 +500,10 @@ namespace strutil
      * @param tokens - container of strings.
      * @return container of non-empty tokens.
      */
-    template<template<class> class Container>
+    template<template<typename> typename Container>
     static inline Container<std::string> drop_empty_copy(Container<std::string> tokens)
     {
-        drop_empty(tokens);
+        drop_empty<Container>(tokens);
         return tokens;
     }
 

--- a/tests/test_cases.cpp
+++ b/tests/test_cases.cpp
@@ -439,41 +439,76 @@ TEST(Regexsplitting_map, regex_split_map)
             ASSERT_EQ(str, ans[each.first]);
         }
     }
-
-    // TODO: More test is to be added.
 }
 
-TEST(Splitting, join)
+TEST(SplittingVector, join)
 {
     std::string str1 = "Col1;Col2;Col3";
     std::vector<std::string> tokens1 = { "Col1", "Col2", "Col3" };
 
-    EXPECT_EQ(str1, strutil::join<std::string>(tokens1, ";"));
+    EXPECT_EQ(str1, strutil::join(tokens1, ";"));
 
     std::string str2 = "1|2|3";
     std::vector<unsigned> tokens2 = { 1, 2, 3 };
 
-    EXPECT_EQ(str2, strutil::join<unsigned>(tokens2, "|"));
+    EXPECT_EQ(str2, strutil::join(tokens2, "|"));
 }
 
-TEST(Splitting, drop_empty)
+TEST(SplittingSet, join)
+{
+    std::string str1 = "Col1;Col2;Col3";
+    std::set<std::string> tokens1 = { "Col1", "Col2", "Col3" };
+
+    EXPECT_EQ(str1, strutil::join(tokens1, ";"));
+
+    std::string str2 = "1|2|3";
+    std::set<unsigned> tokens2 = { 1, 2, 3 };
+
+    EXPECT_EQ(str2, strutil::join(tokens2, "|"));
+}
+
+TEST(SplittingDropEmptyVector, drop_empty)
 {
     std::vector<std::string> tokens = { "t1", "t2", "", "t4", "" };
-    strutil::drop_empty(tokens);
+    strutil::drop_empty<std::vector>(tokens);
     ASSERT_EQ(tokens.size(), 3);
     ASSERT_EQ(tokens[0], "t1");
     ASSERT_EQ(tokens[1], "t2");
     ASSERT_EQ(tokens[2], "t4");
 }
 
-TEST(Splitting, drop_empty_copy)
+TEST(SplittingDropEmptyCopyVector, drop_empty_copy)
 {
     std::vector<std::string> tokens = { "t1", "t2", "", "t4", "" };
-    auto res = strutil::drop_empty_copy(tokens);
+    auto res = strutil::drop_empty_copy<std::vector>(tokens);
     ASSERT_EQ(res.size(), 3);
     ASSERT_EQ(res[0], "t1");
     ASSERT_EQ(res[1], "t2");
     ASSERT_EQ(res[2], "t4");
+}
+
+TEST(SplittingDropEmptySet, drop_empty)
+{
+    std::set<std::string> tokens = { "t1", "t2", "", "t4", ""};
+    strutil::drop_empty<std::set>(tokens);
+    auto it = tokens.begin();
+
+    ASSERT_EQ(tokens.size(), 3);
+    ASSERT_EQ(*(  it), "t1");
+    ASSERT_EQ(*(++it), "t2");
+    ASSERT_EQ(*(++it), "t4");
+}
+
+TEST(SplittingDropEmptyCopySet, drop_empty_copy)
+{
+    std::set<std::string> tokens = { "t1", "t2", "", "t4", "" };
+    auto res = strutil::drop_empty_copy<std::set>(tokens);
+    auto it  = res.begin();
+
+    ASSERT_EQ(res.size(), 3);
+    ASSERT_EQ(*(  it), "t1");
+    ASSERT_EQ(*(++it), "t2");
+    ASSERT_EQ(*(++it), "t4");
 }
 
 TEST(TestDropDuplicate, drop_duplicate)

--- a/tests/test_cases.cpp
+++ b/tests/test_cases.cpp
@@ -470,7 +470,7 @@ TEST(SplittingSet, join)
 TEST(SplittingDropEmptyVector, drop_empty)
 {
     std::vector<std::string> tokens = { "t1", "t2", "", "t4", "" };
-    strutil::drop_empty<std::vector>(tokens);
+    strutil::drop_empty(tokens);
     ASSERT_EQ(tokens.size(), 3);
     ASSERT_EQ(tokens[0], "t1");
     ASSERT_EQ(tokens[1], "t2");
@@ -480,7 +480,7 @@ TEST(SplittingDropEmptyVector, drop_empty)
 TEST(SplittingDropEmptyCopyVector, drop_empty_copy)
 {
     std::vector<std::string> tokens = { "t1", "t2", "", "t4", "" };
-    auto res = strutil::drop_empty_copy<std::vector>(tokens);
+    auto res = strutil::drop_empty_copy(tokens);
     ASSERT_EQ(res.size(), 3);
     ASSERT_EQ(res[0], "t1");
     ASSERT_EQ(res[1], "t2");
@@ -490,7 +490,7 @@ TEST(SplittingDropEmptyCopyVector, drop_empty_copy)
 TEST(SplittingDropEmptySet, drop_empty)
 {
     std::set<std::string> tokens = { "t1", "t2", "", "t4", ""};
-    strutil::drop_empty<std::set>(tokens);
+    strutil::drop_empty(tokens);
     auto it = tokens.begin();
 
     ASSERT_EQ(tokens.size(), 3);
@@ -502,7 +502,7 @@ TEST(SplittingDropEmptySet, drop_empty)
 TEST(SplittingDropEmptyCopySet, drop_empty_copy)
 {
     std::set<std::string> tokens = { "t1", "t2", "", "t4", "" };
-    auto res = strutil::drop_empty_copy<std::set>(tokens);
+    auto res = strutil::drop_empty_copy(tokens);
     auto it  = res.begin();
 
     ASSERT_EQ(res.size(), 3);


### PR DESCRIPTION
The following functions now support the following types:
- join now supports any container type that has begin() and end() methods, including std::set, std::list and std::vector
- drop_empty and drop_empty_copy now support any container of strings with a begin() and end() method
- drop_duplicate and drop_duplicate_copy now support vectors of any data type
- reverse_inplace and reverse_copy now support any container type supported by std::reverse, including std::vector and std::list

Change-Id: Ia40488b96974f9aeece5d84a80800f360c636d05